### PR TITLE
Fix wrong code_based_extension link in doc

### DIFF
--- a/zh_CN/guides/application-design/extension/README.md
+++ b/zh_CN/guides/application-design/extension/README.md
@@ -4,4 +4,4 @@
 
 [api\_based\_extension](api\_based\_extension/ "mention")
 
-[code\_based\_extension](code\based\_extension/ "mention")
+[code\_based\_extension](code\_based\_extension/ "mention")


### PR DESCRIPTION
The URL is currently incorrect.
  
https://github.com/langgenius/dify-docs/blob/main/zh_CN/guides/application-design/extension/code%5Cbased_extension
  
![image](https://github.com/langgenius/dify-docs/assets/5327960/336a2dd8-ab82-4916-87b5-a2440c101105)
