### PR TITLE
Update start-the-frontend-docker-container.md

### DIFF
--- a/zh_CN/getting-started/install-self-hosted/start-the-frontend-docker-container.md
+++ b/zh_CN/getting-started/install-self-hosted/start-the-frontend-docker-container.md
@@ -5,7 +5,7 @@
 #### 直接使用 DockerHub 镜像
 
 ```Bash
-docker run -it -p 3000:3000 -e CONSOLE_URL=http://127.0.0.1:5001 -e APP_URL=http://127.0.0.1:5001 langgenius/dify-web:latest
+docker run -it -p 3000:3000 -e CONSOLE_API_URL=http://127.0.0.1:5001 -e APP_API_URL=http://127.0.0.1:5001 langgenius/dify-web:latest
 ```
 
 #### 源码构建 Docker 镜像
@@ -18,7 +18,7 @@ docker run -it -p 3000:3000 -e CONSOLE_URL=http://127.0.0.1:5001 -e APP_URL=http
 2.  启动前端镜像
 
     ```
-    docker run -it -p 3000:3000 -e CONSOLE_URL=http://127.0.0.1:5001 -e APP_URL=http://127.0.0.1:5001 dify-web
+    docker run -it -p 3000:3000 -e CONSOLE_API_URL=http://127.0.0.1:5001 -e APP_API_URL=http://127.0.0.1:5001 dify-web
     ```
 3. 当控制台域名和 Web APP 域名不一致时，可单独设置 `CONSOLE_URL` 和 `APP_URL`
 4. 本地访问 [http://127.0.0.1:3000](http://127.0.0.1:3000)


### PR DESCRIPTION
fix: update Docker environment variables

Correct Docker startup parameters by changing environment variables from CONSOLE_URL, APP_URL to CONSOLE_API_URL, CONSOLE_API_URL.

- Match web Docker configuration file.
- Verified that the application starts correctly with the new environment variables.