### PR TITLE
Fix the backend readme and frontend readme links

### DIFF
--- a/en/community/contribution.md
+++ b/en/community/contribution.md
@@ -77,7 +77,7 @@ Dify requires the following dependencies to build, make sure they're installed o
 
 #### 4. Installations
 
-Dify is composed of a backend and a frontend. Navigate to the backend directory by `cd api/`, then follow the Backend README to install it. In a separate terminal, navigate to the frontend directory by `cd web/`, then follow the Frontend README to install.
+Dify is composed of a backend and a frontend. Navigate to the backend directory by `cd api/`, then follow the  [Backend README](https://github.com/langgenius/dify/blob/main/api/README.md) to install it. In a separate terminal, navigate to the frontend directory by `cd web/`, then follow the [Frontend README](https://github.com/langgenius/dify/blob/main/web/README.md) to install.
 
 Check the [installation FAQ](https://docs.dify.ai/getting-started/faq/install-faq) for a list of common issues and steps to troubleshoot.
 

--- a/zh_CN/community/contribution.md
+++ b/zh_CN/community/contribution.md
@@ -78,7 +78,7 @@ Dify 依赖以下工具和库：
 
 ### 4. 安装
 
-Dify由后端和前端组成。通过`cd api/`导航到后端目录，然后按照[后端README](api/README.md)进行安装。在另一个终端中，通过`cd web/`导航到前端目录，然后按照[前端README](web/README.md)进行安装。
+Dify由后端和前端组成。通过`cd api/`导航到后端目录，然后按照[后端README](https://github.com/langgenius/dify/blob/main/api/README.md)进行安装。在另一个终端中，通过`cd web/`导航到前端目录，然后按照[前端README](https://github.com/langgenius/dify/blob/main/web/README.md)进行安装。
 
 查看[安装常见问题解答](https://docs.dify.ai/getting-started/faq/install-faq)以获取常见问题列表和故障排除步骤。
 


### PR DESCRIPTION
中文文档[成为贡献者]的页面中，后端README和前端README两个链接已经是坏链，打开404，文档页面在此：https://docs.dify.ai/v/zh-hans/community/contribution

我直接将连接指向了dify仓库里的文档位置，目前还没有中文版所以只能指向英文链接。另外也将英文版的[Become a Contributor]做了一个同样的处理