### PR TITLE
docs: fix Japanese documentation links

### DIFF
--- a/jp/getting-started/install-self-hosted/README.md
+++ b/jp/getting-started/install-self-hosted/README.md
@@ -2,8 +2,8 @@
 
 Dify コミュニティ版はオープンソース版で、以下の2つの方法のいずれかでデプロイできます：
 
-* [Docker Compose デプロイ](https://docs.dify.ai/v/zh-hans/getting-started/install-self-hosted/docker-compose)
-* [ローカルソースコードで起動](https://docs.dify.ai/v/zh-hans/getting-started/install-self-hosted/local-source-code)
+* [Docker Compose デプロイ](https://docs.dify.ai/v/japanese/getting-started/install-self-hosted/docker-compose)
+* [ローカルソースコードで起動](https://docs.dify.ai/v/japanese/getting-started/install-self-hosted/local-source-code)
 
 GitHub で [Dify コミュニティ版](https://github.com/langgenius/dify) をご覧ください。
 
@@ -11,4 +11,4 @@ GitHub で [Dify コミュニティ版](https://github.com/langgenius/dify) を�
 
 正確な審査を確保するため、直接変更をコミットする権限を持つ寄稿者を含むすべてのコードの寄稿は、PR（プルリクエスト）を提出し、マージされる前にコア開発者の承認を得る必要があります。
 
-私たちはすべての人のPRを歓迎します！ご協力いただける場合は、[寄稿ガイド](https://github.com/langgenius/dify/blob/main/CONTRIBUTING_CN.md) でプロジェクトに貢献する方法についての詳細を確認できます。
+私たちはすべての人のPRを歓迎します！ご協力いただける場合は、[寄稿ガイド](https://github.com/langgenius/dify/blob/main/CONTRIBUTING_JA.md) でプロジェクトに貢献する方法についての詳細を確認できます。


### PR DESCRIPTION
I have corrected the error in the link to the Japanese documentation.