### PR TITLE
Fix urls in contribution page

### DIFF
--- a/en/community/contribution.md
+++ b/en/community/contribution.md
@@ -6,7 +6,7 @@ We need to be nimble and ship fast given where we are, but we also want to make 
 
 This guide, like Dify itself, is a constant work in progress. We highly appreciate your understanding if at times it lags behind the actual project, and welcome any feedback for us to improve.
 
-In terms of licensing, please take a minute to read our short License and Contributor Agreement. The community also adheres to the [code of conduct](https://github.com/langgenius/.github/blob/main/CODE\_OF\_CONDUCT.md).
+In terms of licensing, please take a minute to read our short [License and Contributor Agreement](./open-source). The community also adheres to the [code of conduct](https://github.com/langgenius/.github/blob/main/CODE\_OF\_CONDUCT.md).
 
 ### Before you jump in
 
@@ -87,7 +87,12 @@ To validate your set up, head over to [http://localhost:3000](http://localhost:3
 
 ### Developing
 
-If you are adding a model provider, [this guide](https://github.com/langgenius/dify/blob/main/api/core/model\_runtime/README.md) is for you.
+If you are adding a model provider,[this guide](https://github.com/langgenius/dify/blob/main/api/core/model\_runtime/README.md) is for you.
+
+如果您要向Agent或Workflow添加工具提供程序，请参考此指南。
+
+If you are adding tools used in Agent Assistants and Workflows, [this guide](https://github.com/langgenius/dify/blob/main/api/core/tools/README.md) is for you.
+
 
 To help you quickly navigate where your contribution fits, a brief, annotated outline of Dify's backend & frontend is as follows:
 

--- a/en/community/contribution.md
+++ b/en/community/contribution.md
@@ -89,8 +89,6 @@ To validate your set up, head over to [http://localhost:3000](http://localhost:3
 
 If you are adding a model provider,[this guide](https://github.com/langgenius/dify/blob/main/api/core/model\_runtime/README.md) is for you.
 
-如果您要向Agent或Workflow添加工具提供程序，请参考此指南。
-
 If you are adding tools used in Agent Assistants and Workflows, [this guide](https://github.com/langgenius/dify/blob/main/api/core/tools/README.md) is for you.
 
 

--- a/jp/community/contribution.md
+++ b/jp/community/contribution.md
@@ -6,7 +6,7 @@ Difyに貢献したいと思っていることには素晴らしいと思いま�
 
 このガイドは、Dify自体と同様に、常に改善されています。時折プロジェクトの実態よりも遅れることがあるかもしれませんが、ご理解と改善のためのフィードバックを心から歓迎します。
 
-ライセンスに関しては、時間を取って短い[ライセンスと貢献者協定](./license)を読んでください。また、コミュニティは[行動規範](https://github.com/langgenius/.github/blob/main/CODE_OF_CONDUCT.md)にも従います。
+ライセンスに関しては、時間を取って短い[ライセンスと貢献者協定](./open-source)を読んでください。また、コミュニティは[行動規範](https://github.com/langgenius/.github/blob/main/CODE_OF_CONDUCT.md)にも従います。
 
 ## 始める前に
 
@@ -90,7 +90,7 @@ Difyはバックエンドとフロントエンドで構成されています。`
 
 モデルを追加提供する場合は、[このガイド](https://github.com/langgenius/dify/blob/main/api/core/model_runtime/README.md)を参照してください。
 
-エージェントやワークフローにツールを追加提供する場合は、[このガイド](./api/core/tools/README.md)を参照してください。
+エージェントやワークフローにツールを追加提供する場合は、[このガイド](https://github.com/langgenius/dify/blob/main/api/core/tools/README.md)を参照してください。
 
 貢献する部分を迅速に理解できるように、以下にDifyのバックエンドとフロントエンドの簡単な注釈付きアウトラインを示します：
 

--- a/zh_CN/community/contribution.md
+++ b/zh_CN/community/contribution.md
@@ -6,7 +6,7 @@
 
 这份指南，就像 Dify 本身一样，是一个不断改进的工作。如果有时它落后于实际项目，我们非常感谢你的理解，并欢迎任何反馈以供我们改进。
 
-在许可方面，请花一分钟阅读我们简短的[许可证和贡献者协议](./license)。社区还遵守[行为准则](https://github.com/langgenius/.github/blob/main/CODE_OF_CONDUCT.md)。
+在许可方面，请花一分钟阅读我们简短的[许可证和贡献者协议](./open-source)。社区还遵守[行为准则](https://github.com/langgenius/.github/blob/main/CODE_OF_CONDUCT.md)。
 
 ## 在开始之前
 
@@ -90,7 +90,7 @@ Dify由后端和前端组成。通过`cd api/`导航到后端目录，然后按�
 
 如果您要添加模型提供程序，请参考[此指南](https://github.com/langgenius/dify/blob/main/api/core/model_runtime/README.md)。
 
-如果您要向Agent或Workflow添加工具提供程序，请参考[此指南](./api/core/tools/README.md)。
+如果您要向Agent或Workflow添加工具提供程序，请参考[此指南](https://github.com/langgenius/dify/blob/main/api/core/tools/README.md)。
 
 为了帮助您快速了解您的贡献在哪个部分，以下是Dify后端和前端的简要注释大纲：
 


### PR DESCRIPTION
Hi Dify Team,

I've noticed some hyperlinks do not works, and here is a quick fix.

Moreover, I suggest you align the design across lanaguages:
1. You use `https://docs.dify.ai/v/zh-hans/guides/gong-ju` in zh-CN but use `https://docs.dify.ai/guides/tools` in en-US.
2. Lang code is not the same : `.../v/japanese/` ,  `.../v/zh-hans` , and default path is English. 

I understand that document design is not the top priority compared to the rapidly changing requirements of Dify itself. But you can take this as the roadmap or I am willing to help, I would like to know if someone/some team is working with:

1. Align the design of doc path, for example , the tools page could be like: 
   - https://docs.dify.ai/en-us/guides/tools
   - https://docs.dify.ai/zh-cn/guides/tools
   - https://docs.dify.ai/ja-jp/guides/tools

Regards,