### PR TITLE
Fix:Typo External Knowledge API Docs

### DIFF
--- a/en/.gitbook/assets/Dify-test.openapi.json
+++ b/en/.gitbook/assets/Dify-test.openapi.json
@@ -58,7 +58,7 @@
                   "type": "object",
                   "properties": {
                     "records": {
-                      "type": "object",
+                      "type": "array",
                       "properties": {
                         "content": {
                           "type": "string",

--- a/en/.gitbook/assets/Dify-test.openapi.json
+++ b/en/.gitbook/assets/Dify-test.openapi.json
@@ -20,7 +20,7 @@
                     "description": "Your knowledge's unique ID"
                   },
                   "query": { "type": "string", "description": "User's query" },
-                  "retrival_setting": {
+                  "retrieval_setting": {
                     "type": "object",
                     "properties": {
                       "top_k": {
@@ -39,12 +39,12 @@
                     "required": ["top_k", "score_threshold"]
                   }
                 },
-                "required": ["knowledge_id", "query", "retrival_setting"]
+                "required": ["knowledge_id", "query", "retrieval_setting"]
               },
               "example": {
                 "knowledge_id": "your-knowledge-id",
                 "query": "your question",
-                "retrival_setting": { "top_k": 2, "score_threshold": 0.5 }
+                "retrieval_setting": { "top_k": 2, "score_threshold": 0.5 }
               }
             }
           }

--- a/en/.gitbook/assets/Dify-test.openapi.json
+++ b/en/.gitbook/assets/Dify-test.openapi.json
@@ -74,7 +74,7 @@
                           "description": "Document title"
                         },
                         "metadata": {
-                          "type": "string",
+                          "type": "object",
                           "description": "Contains metadata attributes and their values for the document in the data source."
                         }
                       },

--- a/jp/.gitbook/assets/Dify-test.openapi.jp.json
+++ b/jp/.gitbook/assets/Dify-test.openapi.jp.json
@@ -20,7 +20,7 @@
                     "description": "君のナレッジベースの唯一のID"
                   },
                   "query": { "type": "string", "description": "ユーザーのクエリ" },
-                  "retrival_setting": {
+                  "retrieval_setting": {
                     "type": "object",
                     "properties": {
                       "top_k": {
@@ -39,12 +39,12 @@
                     "required": ["top_k", "score_threshold"]
                   }
                 },
-                "required": ["knowledge_id", "query", "retrival_setting"]
+                "required": ["knowledge_id", "query", "retrieval_setting"]
               },
               "example": {
                 "knowledge_id": "your-knowledge-id",
                 "query": "your question",
-                "retrival_setting": { "top_k": 2, "score_threshold": 0.5 }
+                "retrieval_setting": { "top_k": 2, "score_threshold": 0.5 }
               }
             }
           }

--- a/jp/.gitbook/assets/Dify-test.openapi.jp.json
+++ b/jp/.gitbook/assets/Dify-test.openapi.jp.json
@@ -58,7 +58,7 @@
                   "type": "object",
                   "properties": {
                     "records": {
-                      "type": "object",
+                      "type": "array",
                       "properties": {
                         "content": {
                           "type": "string",

--- a/jp/.gitbook/assets/Dify-test.openapi.jp.json
+++ b/jp/.gitbook/assets/Dify-test.openapi.jp.json
@@ -74,7 +74,7 @@
                           "description": "ドキュメントの名前"
                         },
                         "metadata": {
-                          "type": "string",
+                          "type": "object",
                           "description": "データソース内のドキュメントのメタデータ属性とその値が含まれます。"
                         }
                       },

--- a/zh_CN/.gitbook/assets/外部知识库 API.json
+++ b/zh_CN/.gitbook/assets/外部知识库 API.json
@@ -58,7 +58,7 @@
                   "type": "object",
                   "properties": {
                     "records": {
-                      "type": "object",
+                      "type": "array",
                       "properties": {
                         "content": {
                           "type": "string",

--- a/zh_CN/.gitbook/assets/外部知识库 API.json
+++ b/zh_CN/.gitbook/assets/外部知识库 API.json
@@ -20,7 +20,7 @@
                     "description": "你的知识库唯一 ID"
                   },
                   "query": { "type": "string", "description": "用户的提问" },
-                  "retrival_setting": {
+                  "retrieval_setting": {
                     "type": "object",
                     "properties": {
                       "top_k": {
@@ -39,12 +39,12 @@
                     "required": ["top_k", "score_threshold"]
                   }
                 },
-                "required": ["knowledge_id", "query", "retrival_setting"]
+                "required": ["knowledge_id", "query", "retrieval_setting"]
               },
               "example": {
                 "knowledge_id": "your-knowledge-id",
                 "query": "your question",
-                "retrival_setting": { "top_k": 2, "score_threshold": 0.5 }
+                "retrieval_setting": { "top_k": 2, "score_threshold": 0.5 }
               }
             }
           }

--- a/zh_CN/.gitbook/assets/外部知识库 API.json
+++ b/zh_CN/.gitbook/assets/外部知识库 API.json
@@ -74,7 +74,7 @@
                           "description": " 文档标题"
                         },
                         "metadata": {
-                          "type": "string",
+                          "type": "object",
                           "description": "包含数据源中文档的元数据属性及其值。"
                         }
                       },


### PR DESCRIPTION
The external knowledge api doc have some errors.
 1.it should be "retrieval_setting" not "retrival_setting" of the request body.
 2. the type of response's records should be array.
 3. the type of response's metadata should be object.
Fixes #312 