### PR TITLE
Docs - Update configuration to use ollama with dify

### DIFF
--- a/en/development/models-integration/ollama.md
+++ b/en/development/models-integration/ollama.md
@@ -31,7 +31,7 @@
 
         Enter the base URL where the Ollama service is accessible.
 
-        If Dify is deployed using docker, consider using the local network IP address, e.g., `http://192.168.1.100:11434` or the docker host machine IP address, e.g., `http://172.17.0.1:11434`.
+        If Dify is deployed using Docker, consider using the local network IP address, e.g., http://192.168.1.100:11434, the Docker host machine IP address, e.g., http://172.17.0.1:11434, or http://host.docker.internal:11434 to access the service.
 
         For local source code deployment, use `http://localhost:11434`.
     * Model Type: `Chat`


### PR DESCRIPTION
Added support for accessing Dify via http://host.docker.internal:11434, which provides a convenient alternative for users running Docker on compatible systems. This update complements the existing options of using the local network IP or the Docker host IP address. It enhances flexibility, especially for setups where host.docker.internal is a preferred method. 