### PR TITLE
Fix typo, PostgresSQL to PostgreSQL.

### DIFF
--- a/en/getting-started/install-self-hosted/local-source-code.md
+++ b/en/getting-started/install-self-hosted/local-source-code.md
@@ -20,7 +20,7 @@
 git clone https://github.com/langgenius/dify.git
 ```
 
-Before enabling business services, we need to first deploy PostgresSQL / Redis / Weaviate (if not locally available). We can start them with the following commands:
+Before enabling business services, we need to first deploy PostgreSQL / Redis / Weaviate (if not locally available). We can start them with the following commands:
 
 ```Bash
 cd docker

--- a/jp/getting-started/install-self-hosted/local-source-code.md
+++ b/jp/getting-started/install-self-hosted/local-source-code.md
@@ -20,7 +20,7 @@ Dify コードをクローン：
 git clone https://github.com/langgenius/dify.git
 ```
 
-ビジネスサービスを有効にする前に、PostgresSQL / Redis / Weaviate（ローカルにない場合）をデプロイする必要があります。以下のコマンドで起動できます：
+ビジネスサービスを有効にする前に、PostgreSQL / Redis / Weaviate（ローカルにない場合）をデプロイする必要があります。以下のコマンドで起動できます：
 
 ```Bash
 cd docker

--- a/zh_CN/getting-started/install-self-hosted/local-source-code.md
+++ b/zh_CN/getting-started/install-self-hosted/local-source-code.md
@@ -20,7 +20,7 @@ Clone Dify 代码：
 git clone https://github.com/langgenius/dify.git
 ```
 
-在启用业务服务之前，我们需要先部署 PostgresSQL / Redis / Weaviate（如果本地没有的话），可以通过以下命令启动：
+在启用业务服务之前，我们需要先部署 PostgreSQL / Redis / Weaviate（如果本地没有的话），可以通过以下命令启动：
 
 ```Bash
 cd docker


### PR DESCRIPTION
Hi.
I fixed typos "PostgreSQL" in the local source code deployment documentation for each language.