### PR TITLE
fix: bedrock typo caused 404 problem

### DIFF
--- a/zh_CN/learn-more/use-cases/how-to-connect-aws-bedrock.md
+++ b/zh_CN/learn-more/use-cases/how-to-connect-aws-bedrock.md
@@ -115,7 +115,7 @@ class ExternalDatasetService:
 
 ### 3. 获取 AWS Bedrock Knowledge Base ID
 
-登录 AWS Bedrock Knowledge 后台，获取已创建 Knowledge Base 的 ID。此参数将会在[后续步骤](how-to-connect-aws-bderock.md#id-5.-lian-jie-wai-bu-zhi-shi-ku)用于与 Dify 平台的连接。
+登录 AWS Bedrock Knowledge 后台，获取已创建 Knowledge Base 的 ID。此参数将会在[后续步骤](how-to-connect-aws-bedrock.md#id-5.-lian-jie-wai-bu-zhi-shi-ku)用于与 Dify 平台的连接。
 
 <figure><img src="../../.gitbook/assets/image (359).png" alt=""><figcaption><p>获取 AWS Bedrock Knowledge Base ID</p></figcaption></figure>
 
@@ -126,8 +126,8 @@ class ExternalDatasetService:
 按照页面提示，依次填写以下内容：
 
 * 知识库的名称，允许自定义名称，用于区分 Dify 平台内所连接的不同外部知识 API；
-* API 接口地址，外部知识库的连接地址，可在[第二步](how-to-connect-aws-bderock.md#id-2.-gou-jian-hou-duan-api-fu-wu)中自定义。示例 `api-endpoint/retrieval`；
-* API Key，外部知识库连接密钥，可在[第二步](how-to-connect-aws-bderock.md#id-2.-gou-jian-hou-duan-api-fu-wu)中自定义。
+* API 接口地址，外部知识库的连接地址，可在[第二步](how-to-connect-aws-bedrock.md#id-2.-gou-jian-hou-duan-api-fu-wu)中自定义。示例 `api-endpoint/retrieval`；
+* API Key，外部知识库连接密钥，可在[第二步](how-to-connect-aws-bedrock.md#id-2.-gou-jian-hou-duan-api-fu-wu)中自定义。
 
 <figure><img src="../../.gitbook/assets/image (362).png" alt=""><figcaption></figcaption></figure>
 
@@ -142,10 +142,10 @@ class ExternalDatasetService:
 * **知识库名称与描述**
 *   **外部知识库 API**
 
-    选择在[第四步](how-to-connect-aws-bderock.md#id-4.-guan-lian-wai-bu-zhi-shi-api)中关联的外部知识库 API
+    选择在[第四步](how-to-connect-aws-bedrock.md#id-4.-guan-lian-wai-bu-zhi-shi-api)中关联的外部知识库 API
 *   **外部知识库 ID**
 
-    填写在[第三步](how-to-connect-aws-bderock.md#id-3.-huo-qu-aws-bedrock-knowledge-base-id)中获取的 AWS Bedrock knowledge base ID
+    填写在[第三步](how-to-connect-aws-bedrock.md#id-3.-huo-qu-aws-bedrock-knowledge-base-id)中获取的 AWS Bedrock knowledge base ID
 *   **调整召回设置**
 
     \*\*Top K：\*\*用户发起提问时，将请求外部知识 API 获取相关性较高的内容分段。该参数用于筛选与用户问题相似度较高的文本片段。默认值为 3，数值越高，召回存在相关性的文本分段也就越多。


### PR DESCRIPTION
fix 404 problem in bedrock knowledge base 