### PR TITLE
add a note to help users know how to make the modification of file size limit for uploading to the knowledge base  take effect

### DIFF
--- a/en/getting-started/install-self-hosted/environments.md
+++ b/en/getting-started/install-self-hosted/environments.md
@@ -411,7 +411,7 @@ Used to store uploaded data set files, team/tenant encryption keys, and other fi
 
 - UPLOAD_FILE_SIZE_LIMIT:
 
-  Upload file size limit, default 15M.
+  Upload file size limit, default 15M.<mark>Note：After modifying the UPLOAD_FILE_SIZE_LIMIT, you also need to synchronously update the value of NGINX_CLIENT_MAX_BODY_SIZE; otherwise, it will not take effect, and the front-end interface will display an "Upload Failed" message in the upper right corner.</mark>
 
 - UPLOAD_FILE_BATCH_LIMIT
 

--- a/zh_CN/getting-started/install-self-hosted/environments.md
+++ b/zh_CN/getting-started/install-self-hosted/environments.md
@@ -393,7 +393,7 @@ Flask 调试模式，开启可在接口输出 trace 信息，方便调试。
 
 *   UPLOAD\_FILE\_SIZE\_LIMIT
 
-    上传文件大小限制，默认 15M。
+    上传文件大小限制，默认 15M。<mark>Note：修改完UPLOAD_FILE_SIZE_LIMIT后还要同步修改NGINX_CLIENT_MAX_BODY_SIZE的值，才能使得生效。否则前端界面右上角会提升"上传失败"。</mark>
 *   UPLOAD\_FILE\_BATCH\_LIMIT
 
     每次上传文件数上限，默认 5 个。


### PR DESCRIPTION
add a note to help users know how to make the modification of file size limit for uploading to the knowledge base  take effect

新增了一个备注，让用户知道如何让修改上传到知识库的文档大小限制生效。