### PR TITLE
Checkout the current latest version of Dify source code.

### DIFF
--- a/en/getting-started/install-self-hosted/docker-compose.md
+++ b/en/getting-started/install-self-hosted/docker-compose.md
@@ -22,7 +22,8 @@
 Clone the Dify source code to your local machine:
 
 ```bash
-git clone https://github.com/langgenius/dify.git
+# Assuming current latest version is 0.15.3
+git clone https://github.com/langgenius/dify.git --branch 0.15.3
 ```
 
 ### Starting Dify

--- a/jp/getting-started/install-self-hosted/docker-compose.md
+++ b/jp/getting-started/install-self-hosted/docker-compose.md
@@ -18,7 +18,8 @@
 Difyのソースコードをローカルにクローンします
 
 ```bash
-git clone https://github.com/langgenius/dify.git
+# 現在の最新バージョンは0.15.3だと仮定すると
+git clone https://github.com/langgenius/dify.git --branch 0.15.3
 ```
 
 ### Difyの起動

--- a/zh_CN/getting-started/install-self-hosted/docker-compose.md
+++ b/zh_CN/getting-started/install-self-hosted/docker-compose.md
@@ -18,7 +18,8 @@
 克隆 Dify 源代码至本地环境。
 
 ```bash
-git clone https://github.com/langgenius/dify.git
+# 假设当前最新版本为 0.15.3
+git clone https://github.com/langgenius/dify.git --branch 0.15.3
 ```
 
 ### 启动 Dify


### PR DESCRIPTION
Checkout code from the latest release branch instead of the `main` branch can help avoid issues caused by features that are still under development.