### PR TITLE
fix "npm error command sh -c npx only-allow pnpm" problem when instal…

### DIFF
--- a/en/getting-started/install-self-hosted/local-source-code.md
+++ b/en/getting-started/install-self-hosted/local-source-code.md
@@ -192,7 +192,8 @@ Please visit [https://nodejs.org/en/download](https://nodejs.org/en/download) an
 2.  Install the dependencies.
 
     ```
-    npm install
+    npm i -g pnpm
+    pnpm install
     ```
 
 3.  Configure the environment variables. Create a file named .env.local in the current directory and copy the contents from .env.example. Modify the values of these environment variables according to your requirements:

--- a/jp/getting-started/install-self-hosted/local-source-code.md
+++ b/jp/getting-started/install-self-hosted/local-source-code.md
@@ -185,7 +185,8 @@ https://nodejs.org/en/download から対応するOSのv18.x以上のインスト
 2.  依存関係をインストール
 
     ```
-    npm install
+    npm i -g pnpm
+    pnpm install
     ```
 3.  環境変数を構成。現在のディレクトリに `.env.local` ファイルを作成し、`.env.example` の内容をコピーします。必要に応じてこれらの環境変数の値を変更します。
 

--- a/zh_CN/getting-started/install-self-hosted/local-source-code.md
+++ b/zh_CN/getting-started/install-self-hosted/local-source-code.md
@@ -187,7 +187,8 @@ Web 前端服务启动需要用到 [Node.js v18.x (LTS)](http://nodejs.org) 、[
 2.  安装依赖包
 
     ```
-    npm install
+    npm i -g pnpm
+    pnpm install
     ```
 3.  配置环境变量。在当前目录下创建文件 `.env.local`，并复制`.env.example`中的内容。根据需求修改这些环境变量的值:
 


### PR DESCRIPTION
use 'npm install' will cause an error below:

> npx only-allow pnpm

╔═════════════════════════════════════════════════════════════╗
║                                                             ║
║   Use "pnpm install" for installation in this project.      ║
║                                                             ║
║   If you don't have pnpm, install it via "npm i -g pnpm".   ║
║   For more details, go to https://pnpm.js.org/              ║
║                                                             ║
╚═════════════════════════════════════════════════════════════╝
