### PR TITLE
Fixed translation of "Endpoint" from "接口" to "端点"

### DIFF
--- a/zh_CN/plugins/schema-definition/reverse-invocation-of-the-dify-service/model.md
+++ b/zh_CN/plugins/schema-definition/reverse-invocation-of-the-dify-service/model.md
@@ -14,7 +14,7 @@
     self.session.model.llm
 ```
 
-#### **接口**
+#### **端点**
 
 ```python
     def invoke(
@@ -156,7 +156,7 @@ class LLMTool(Tool):
 
 ### 调用 Summary
 
-你可以请求该接口来总结一段文本，它会使用你当前 workspace 内的系统模型来总结文本。
+你可以请求该端点来总结一段文本，它会使用你当前 workspace 内的系统模型来总结文本。
 
 **入口**
 
@@ -164,7 +164,7 @@ class LLMTool(Tool):
     self.session.model.summary
 ```
 
-**接口**
+**端点**
 
 * `text` 为需要被总结的文本。
 * `instruction` 为你想要额外添加的指令，它可以让你风格化地总结文本。
@@ -183,7 +183,7 @@ class LLMTool(Tool):
     self.session.model.text_embedding
 ```
 
-**接口**
+**端点**
 
 ```python
     def invoke(
@@ -200,7 +200,7 @@ class LLMTool(Tool):
     self.session.model.rerank
 ```
 
-**接口**
+**端点**
 
 ```python
     def invoke(
@@ -217,7 +217,7 @@ class LLMTool(Tool):
     self.session.model.tts
 ```
 
-**接口**
+**端点**
 
 ```python
     def invoke(
@@ -226,7 +226,7 @@ class LLMTool(Tool):
         pass
 ```
 
-请注意 `tts` 接口返回的 `bytes` 流是一个 `mp3` 音频字节流，每一轮迭代返回的都是一个完整的音频。如果你想做更深入的处理任务，请选择合适的库进行。
+请注意 `tts` 端点返回的 `bytes` 流是一个 `mp3` 音频字节流，每一轮迭代返回的都是一个完整的音频。如果你想做更深入的处理任务，请选择合适的库进行。
 
 ### 调用 Speech2Text
 
@@ -236,7 +236,7 @@ class LLMTool(Tool):
     self.session.model.speech2text
 ```
 
-**接口**
+**端点**
 
 ```python
     def invoke(
@@ -255,11 +255,11 @@ class LLMTool(Tool):
     self.session.model.moderation
 ```
 
-**接口**
+**端点**
 
 ```python
     def invoke(self, model_config: ModerationModelConfig, text: str) -> bool:
         pass
 ```
 
-若该接口返回 `true` 则表示 `text` 中包含敏感内容。
+若该端点返回 `true` 则表示 `text` 中包含敏感内容。


### PR DESCRIPTION
In the original English topic, the term here used is "Endpoint", however, the translated topic used "接口" for "Endpoint" which could lead to confusion, as the translation "接口" is widely used for the term "interface," which is also widely used throughout the Dify document.